### PR TITLE
programatically target membership of heresdk framework to react-native-here-explore

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -108,12 +108,27 @@ target 'MapsHereExample' do
   pod 'heresdk', :path => 'Frameworks'
 end
 ```
+add this code block to the Podfile that automatically sets the target membership of the here framework to react-native-here-explore package inside `post_install`
+
+```podspec
+  post_install do |installer|
+    # ... some stuff
+       if target.name  == "react-native-here-explore"
+         all_filerefs = installer.pods_project.files
+         all_filerefs.each do |fileref|
+            if fileref.path.end_with? "heresdk.xcframework"
+             build_phase = target.frameworks_build_phase
+             unless build_phase.files_references.include?(fileref)
+               build_phase.add_file_reference(fileref)
+             end
+           end
+         end
+       end
+    # ... some stuff
+    end
+```
 
 Finally, in your terminal, run `pod install`.
-
-If the app doesn't run properly on iOS, then you have to manually add `react-native-here-explore` to the Target Membership of `heresdk`. You do so by opening Xcode and navigating to the `heresdk.xcframework` package inside the `Pods/Development Pods/heresdk`, then checking `react-native-here-explore` on the right menu as shown in the image below:
-
-<img src="assets/xcode_heresdk_target_membership.png" alt="XCode HERE SDK Target Membership" title="XCode HERE SDK Target Membership" width="100%">
 
 ## Authenticate using credentials
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -41,18 +41,13 @@ target 'HereExploreExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
-     puts("add heresdk.xcframework reference to react-native-here-explore project.")
      installer.pods_project.targets.each do |target|
        if target.name  == "react-native-here-explore"
-         puts("Found react-native-here-explore target.")
          all_filerefs = installer.pods_project.files
          all_filerefs.each do |fileref|
             if fileref.path.end_with? "heresdk.xcframework"
-             puts("Found heresdk.xcframework fileref.")
              build_phase = target.frameworks_build_phase
-             puts("Determining if react-native-here-explore build phase needs correction.")
              unless build_phase.files_references.include?(fileref)
-               puts("Adding heresdk.xcframework to react-native-here-explore target")
                build_phase.add_file_reference(fileref)
              end
            end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -41,5 +41,23 @@ target 'HereExploreExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+     puts("add heresdk.xcframework reference to react-native-here-explore project.")
+     installer.pods_project.targets.each do |target|
+       if target.name  == "react-native-here-explore"
+         puts("Found react-native-here-explore target.")
+         all_filerefs = installer.pods_project.files
+         all_filerefs.each do |fileref|
+            if fileref.path.end_with? "heresdk.xcframework"
+             puts("Found heresdk.xcframework fileref.")
+             build_phase = target.frameworks_build_phase
+             puts("Determining if react-native-here-explore build phase needs correction.")
+             unless build_phase.files_references.include?(fileref)
+               puts("Adding heresdk.xcframework to react-native-here-explore target")
+               build_phase.add_file_reference(fileref)
+             end
+           end
+         end
+       end
+     end
   end
 end


### PR DESCRIPTION
Your [Installation.md](https://github.com/ajakka/react-native-here-explore/blob/main/docs/INSTALLATION.md)  mentions that some users may encounter issues with the `heresdk.xcframework` until they manually set the framework's target membership to `here-sdk-here-explore` in Xcode. Without this manual step, the build process may fail with an error stating "HERE SDK is not found."

Manually setting the target membership leads to several challenges:

1. Repetitive Task: Developers need to reset the target membership after each project clean build, whether done through Xcode or command line.
2. Onboarding Friction: New developers must manually set the target membership each time they clone the repository.
3. CI/CD Limitations: It's not feasible to set the target membership in GitHub Actions during release processes, as there's no access to the Xcode GUI in the cloud environment.

 Proposed Solution:
To address these issues, we can add a code block to the Podfile that automatically sets the target membership. This solution offers several benefits:

- Eliminates the need for manual intervention after clean builds.
- Ensures consistent setup across all developer environments.
- Works seamlessly with CI/CD pipelines, including GitHub Actions.

Implementation
Add the code block to the Podfile (inside `post_install do |installer|...end`) in the `example` directory and add it to the **installation.md** for ios part since it is a set-up step not to be included in the original package code