### PR TITLE
MapPin implementation

### DIFF
--- a/android/src/main/java/com/hereexplore/HereExplorePackage.kt
+++ b/android/src/main/java/com/hereexplore/HereExplorePackage.kt
@@ -11,6 +11,8 @@ import com.hereexplore.features.marker.MarkerViewManager
 import com.hereexplore.features.polygon.PolygonViewManager
 import com.hereexplore.features.polyline.PolylineViewManager
 import com.hereexplore.features.config.ConfigModule
+import com.hereexplore.features.pin.PinViewContentManager
+import com.hereexplore.features.pin.PinViewManager
 import com.hereexplore.features.routing.RoutingModule
 
 class HereExplorePackage : ReactPackage {
@@ -22,6 +24,8 @@ class HereExplorePackage : ReactPackage {
       PolygonViewManager(),
       PolylineViewManager(),
       MarkerViewManager(),
+      PinViewManager(),
+      PinViewContentManager()
     )
   }
 

--- a/android/src/main/java/com/hereexplore/features/pin/PinView.kt
+++ b/android/src/main/java/com/hereexplore/features/pin/PinView.kt
@@ -1,0 +1,51 @@
+package com.hereexplore.features.pin
+
+import android.content.Context
+import android.view.View
+import com.facebook.react.bridge.ReadableMap
+import com.here.sdk.core.Anchor2D
+import com.here.sdk.core.GeoCoordinates
+import com.here.sdk.mapview.MapView
+import com.hereexplore.features.item.ItemView
+import com.hereexplore.helpers.CoordinatesUtils
+
+class PinView(context: Context?) : ItemView(context) {
+
+  private var mapPin: MapView.ViewPin? = null
+  private var geoCoordinates: GeoCoordinates? = null
+  private var anchor2D = Anchor2D(0.5, 0.5)
+  private var pinView: View? = null
+
+  fun setGeoCoordinate(value: ReadableMap?) {
+    if (value != null) {
+      geoCoordinates = CoordinatesUtils.toCoordinates(value)
+    }
+  }
+
+  fun setAnchor(value: ReadableMap?) {
+    if (value != null) {
+      anchor2D.horizontal = if (value.hasKey("horizontal")) value.getDouble("horizontal") else 0.5
+      anchor2D.vertical = if (value.hasKey("vertical")) value.getDouble("vertical") else 0.5
+    }
+  }
+
+  override fun addView(childView: View, childPosition: Int) {
+    pinView = childView
+  }
+
+  override fun updateFeature() {
+    mapPin?.let {
+      mapPin?.unpin()
+    }
+    pinView?.let {
+      mapPin = parentMap?.pinView(it, geoCoordinates)
+      mapPin!!.anchorPoint = anchor2D
+    }
+  }
+
+
+  override fun removeFeature() {
+    mapPin?.let { mapPin?.unpin() }
+    unassignMap()
+  }
+}

--- a/android/src/main/java/com/hereexplore/features/pin/PinViewContent.kt
+++ b/android/src/main/java/com/hereexplore/features/pin/PinViewContent.kt
@@ -1,0 +1,18 @@
+package com.hereexplore.features.pin
+
+import android.content.Context
+import com.facebook.react.views.view.ReactViewGroup
+
+class PinViewContent (context: Context) : ReactViewGroup(context) {
+  /*
+  * Fixes error "A catalyst view must have an explicit width and height given to it. This should normally happen as part of the standard catalyst UI framework"
+  */
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    // force the view to have same dimensions as fist child.
+    // only one child is allowed
+    val child = getChildAt(0);
+    val cw = child?.measuredWidth ?: 0
+    val ch = child?.measuredHeight ?: 0
+    setMeasuredDimension(cw, ch)
+  }
+}

--- a/android/src/main/java/com/hereexplore/features/pin/PinViewContentManager.kt
+++ b/android/src/main/java/com/hereexplore/features/pin/PinViewContentManager.kt
@@ -1,0 +1,16 @@
+package com.hereexplore.features.pin
+
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+
+class PinViewContentManager : ViewGroupManager<PinViewContent>() {
+  companion object {
+    const val NAME = "PinViewContent"
+  }
+
+  override fun getName() = NAME
+
+  override fun createViewInstance(context: ThemedReactContext): PinViewContent {
+    return PinViewContent(context)
+  }
+}

--- a/android/src/main/java/com/hereexplore/features/pin/PinViewManager.kt
+++ b/android/src/main/java/com/hereexplore/features/pin/PinViewManager.kt
@@ -1,0 +1,36 @@
+package com.hereexplore.features.pin
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+
+
+@ReactModule(name = PinViewManager.TAG)
+class PinViewManager : PinViewManagerSpec<PinView>() {
+
+  @ReactProp(name = "geoCoordinates")
+  override fun setGeoCoordinates(view: PinView, value: ReadableMap?) {
+    view.setGeoCoordinate(value)
+  }
+
+  @ReactProp(name = "anchor")
+  override fun setAnchor(view: PinView, value: ReadableMap?) {
+    view.setAnchor(value)
+  }
+
+  override fun onAfterUpdateTransaction(view: PinView) {
+    super.onAfterUpdateTransaction(view)
+    view.updateFeature()
+  }
+
+  override fun getName() = TAG
+
+  override fun createViewInstance(context: ThemedReactContext): PinView {
+    return PinView(context)
+  }
+
+  companion object {
+    const val TAG = "PinView"
+  }
+}

--- a/android/src/main/java/com/hereexplore/features/pin/PinViewManagerSpec.kt
+++ b/android/src/main/java/com/hereexplore/features/pin/PinViewManagerSpec.kt
@@ -1,0 +1,12 @@
+package com.hereexplore.features.pin
+
+import android.view.ViewGroup
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.ViewGroupManager
+
+abstract class PinViewManagerSpec<T : ViewGroup> : ViewGroupManager<T>() {
+
+  abstract fun setGeoCoordinates(view: T, value: ReadableMap?)
+
+  abstract fun setAnchor(view: T, value: ReadableMap?)
+}

--- a/example/src/features/routes/RoutesScreen.tsx
+++ b/example/src/features/routes/RoutesScreen.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import type { GeoCoordinates, GeoPolyline } from 'react-native-here-explore';
 import {
   Map,
   Marker,
+  Pin,
   Polyline,
   RouteOption,
   useRouting,
@@ -68,6 +69,15 @@ export default function RoutesScreen(_: ScreenProps<'Routes'>) {
           lineWidth={16}
           geoPolyline={vertices}
         />
+        <Pin
+          geoCoordinates={centerPoint}
+          anchor={{ horizontal: 0.5, vertical: 1 }}
+        >
+          <View style={styles.pin_container}>
+            <Text style={styles.pin_text}>Custom Pin</Text>
+          </View>
+          <View style={styles.pin_arrow} />
+        </Pin>
       </Map>
 
       <RouteOptionsSelector
@@ -105,5 +115,28 @@ const styles = StyleSheet.create({
     width: '100%',
     alignContent: 'center',
     marginBottom: 16,
+  },
+  pin_container: {
+    padding: 15,
+    backgroundColor: 'black',
+    borderRadius: 10,
+  },
+  pin_text: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  pin_arrow: {
+    width: 0,
+    height: 0,
+    backgroundColor: 'transparent',
+    borderStyle: 'solid',
+    borderLeftWidth: 10,
+    borderRightWidth: 10,
+    borderBottomWidth: 10,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderBottomColor: 'black',
+    transform: [{ rotate: '180deg' }],
+    top: -1,
   },
 });

--- a/ios/Features/Pin/PinViewManager.m
+++ b/ios/Features/Pin/PinViewManager.m
@@ -1,0 +1,8 @@
+#import <React/RCTViewManager.h>
+
+@interface RCT_EXTERN_MODULE(PinViewManager, RCTViewManager)
+
+RCT_EXPORT_VIEW_PROPERTY(geoCoordinates,    NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(anchor,            NSDictionary)
+
+@end

--- a/ios/Features/Pin/PinViewManager.swift
+++ b/ios/Features/Pin/PinViewManager.swift
@@ -1,0 +1,57 @@
+import heresdk
+
+@objc(PinViewManager)
+class PinViewManager: RCTViewManager {
+  
+  @objc override func view() -> (PinView) {
+    return PinView()
+  }
+  
+  @objc override static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+  
+  @objc override static func moduleName() -> String! {
+    return "PinView"
+  }
+}
+
+class PinView: ItemView {
+  var currentPinView: MapView.ViewPin?
+  var pinUIView: UIView? = nil
+  
+  @objc var geoCoordinates: NSDictionary = [:]
+  { didSet {self.updateFeature()} }
+  
+  @objc var anchor: NSDictionary = [:]
+  { didSet {self.updateFeature()} }
+  
+  public override func insertReactSubview(_ subview: UIView!, at atIndex: Int) {
+    pinUIView = subview
+  }
+  
+  override func updateFeature() {
+    guard let pinUIView, let coordinates = toCoordinates(raw: geoCoordinates) else {
+      return
+    }
+    if let oldMapPin = self.currentPinView {
+      self.parentMap?.unpinView(oldMapPin.view)
+    }
+    
+    let anchorPoint = Anchor2D(
+      horizontal: self.anchor["horizontal"] as? CGFloat ?? 0.5,
+      vertical: self.anchor["vertical"] as? CGFloat ?? 0.5
+    )
+    pinUIView.layer.anchorPoint = CGPoint(x: anchorPoint.horizontal, y: anchorPoint.vertical)
+    self.currentPinView = self.parentMap?.pinView(pinUIView, to: coordinates)
+  }
+  
+  override func removeFeature() {
+    if let oldMapPin = currentPinView {
+      self.parentMap?.unpinView(oldMapPin.view)
+    }
+    currentPinView = nil
+    pinUIView = nil
+    unassignMap()
+  }
+}

--- a/src/features/pin/PinContentView.android.tsx
+++ b/src/features/pin/PinContentView.android.tsx
@@ -1,0 +1,48 @@
+import {
+  UIManager,
+  StyleSheet,
+  requireNativeComponent,
+  View,
+  type ViewStyle,
+} from 'react-native';
+
+import { LINKING_ERROR } from '../../constants';
+import type { ReactNode } from 'react';
+
+const COMPONENT_NAME = 'PinViewContent';
+
+export interface PinProps {
+  children: ReactNode;
+  style?: ViewStyle;
+}
+
+const RCTPinContent =
+  UIManager.getViewManagerConfig(COMPONENT_NAME) != null
+    ? requireNativeComponent<PinProps>(COMPONENT_NAME)
+    : () => {
+        throw new Error(LINKING_ERROR);
+      };
+
+/**
+ * Draws a Pin over the given coordinates
+ */
+export function PinContent(props: PinProps) {
+  return (
+    <RCTPinContent style={styles.pin}>
+      <View style={styles.content}>{props.children}</View>
+    </RCTPinContent>
+  );
+}
+
+// Styles required to render Pin at correct position
+const styles = StyleSheet.create({
+  pin: {
+    position: 'absolute',
+  },
+  content: {
+    // some Pins may not render at correct position if this is omitted
+    backgroundColor: 'transparent',
+    alignItems: 'center',
+    alignSelf: 'center',
+  },
+});

--- a/src/features/pin/PinContentView.ios.tsx
+++ b/src/features/pin/PinContentView.ios.tsx
@@ -1,0 +1,23 @@
+import { View, StyleSheet, type ViewStyle } from 'react-native';
+
+import type { ReactNode } from 'react';
+
+export interface PinProps {
+  children: ReactNode;
+  style?: ViewStyle;
+}
+
+/**
+ * Draws a Pin over the given coordinates
+ */
+export function PinContent(props: PinProps) {
+  // ensure single child
+  return <View style={styles.content}>{props.children}</View>;
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+    alignSelf: 'center',
+  },
+});

--- a/src/features/pin/PinView.tsx
+++ b/src/features/pin/PinView.tsx
@@ -1,0 +1,57 @@
+import { UIManager, requireNativeComponent } from 'react-native';
+
+import { LINKING_ERROR } from '../../constants';
+import type { GeoCoordinates } from '../../types/Coordinates';
+import type { ReactNode } from 'react';
+import { PinContent } from './PinContentView';
+
+const COMPONENT_NAME = 'PinView';
+
+export interface PinProps {
+  /**
+   * ### **(REQUIRED)** Position of the pin on the map
+   *
+   * **Example:**
+   * ```
+   * geoCoordinates={{ latitude: 99.00990, longitude: 9.00990, altitude: 1.07 }}
+   * ```
+   */
+  geoCoordinates: GeoCoordinates;
+
+  /**
+   * ### Define the anchor point used to define where the image should be placed relative to the coordinates
+   *
+   * More info on the official [documentation](https://www.here.com/docs/bundle/sdk-for-android-explore-developer-guide/page/topics/map-items.html#anchored-poi-markers)
+   *
+   * **Example:**
+   * ```
+   * anchor={{ horizontal: 0.5, vertical: 0.5 }}
+   * ```
+   */
+  anchor?: { horizontal?: number; vertical?: number };
+
+  /**
+   * ### **(REQUIRED)** Child components to be rendered inside the Pin
+   */
+  children: ReactNode;
+}
+
+const RCTPin =
+  UIManager.getViewManagerConfig(COMPONENT_NAME) != null
+    ? requireNativeComponent<PinProps>(COMPONENT_NAME)
+    : () => {
+        throw new Error(LINKING_ERROR);
+      };
+
+/**
+ * Draws a Pin over the given coordinates
+ */
+export function Pin(props: PinProps) {
+  const { children, ...pinProps } = props;
+
+  return (
+    <RCTPin {...pinProps}>
+      <PinContent>{children}</PinContent>
+    </RCTPin>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,6 @@ export { Polygon, type PolygonProps } from './features/polygon/PolygonView';
 
 export { Marker, type MarkerProps } from './features/marker/MarkerView';
 
+export { Pin, type PinProps } from './features/pin/PinView';
+
 export * from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "moduleSuffixes": [".ios", ".android", ""]
   }
 }


### PR DESCRIPTION
Hi, it's me who recently wrote you the email. Please take a look at this implementation of the Pin map element. 
iOS is pretty straightforward. 
Android uses the PinViewContent to fix crash during render. This is the only way I've found to overcome the issue. Calling `super.onMeasure(...)` always resulted in the crash, even if I tried to makeMeasureSpecs beforehand as they do in [mapboxgl](https://github.com/rnmapbox/maps/blob/main/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt) - I am not sure what they're doing there though.